### PR TITLE
Collected changes to ADL c++ code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ dist: allhaskell
 allhaskell:
 	(cd haskell && stack build)
 
+docker: dist
+	(cd dist && cp `ls -t adl-*-linux.zip | head -n1` hxadl.zip)
+	(cd dist && docker build -t helixta/hxadl:dev .)
 
 runtime-cpp: .make/built-runtime-cpp
 

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,2 @@
+/adl*.zip
+/hxadl.zip

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,0 +1,6 @@
+FROM helixta/hxadl:0.13
+
+#Based on docker history of helixta/hxadl:0.13
+COPY hxadl.zip /tmp/hxadl.zip
+
+RUN unzip -o /tmp/hxadl.zip -d /opt && rm -r /tmp/hxadl.zip

--- a/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
+++ b/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
@@ -502,7 +502,8 @@ generateDecl dn d@(Decl{d_type=(Decl_Struct s)}) = do
        forM_ fds $ \fd -> do
            wt "$1 $2;" [fd_typeExpr fd, fd_fieldName fd]
 
-    declareOperators ifile (s_typeParams s) ctnameP
+    -- Omit comparison operators
+    -- declareOperators ifile (s_typeParams s) ctnameP
 
   write icfile $ do
     -- Constructors
@@ -527,26 +528,26 @@ generateDecl dn d@(Decl{d_type=(Decl_Struct s)}) = do
       cblock $ return ()
 
     -- Non-inline functions
-    wl ""
-    genTemplate (s_typeParams s)
-    wl "bool"
-    wt "operator<( const $1 &a, const $1 &b )" [ctnameP]
-    cblock $ do
-      forM_ fds $ \fd -> do
-        wt "if( a.$1 < b.$1 ) return true;" [fd_fieldName fd]
-        wt "if( b.$1 < a.$1 ) return false;" [fd_fieldName fd]
-      wl "return false;"
-    wl ""
-    genTemplate (s_typeParams s)
-    wl "bool"
-    wt "operator==( const $1 &a, const $1 &b )" [ctnameP]
-    cblock $ do
-      if isEmpty
-        then wl "return true;"
-        else do
-          wl "return"
-          forM_ (sepWithTerm "&&" ";" fds) $ \(fd,sep) -> do
-            indent $ wt "a.$1 == b.$1 $2" [fd_fieldName fd,sep]
+    --wl ""
+    --genTemplate (s_typeParams s)
+    --wl "bool"
+    --wt "operator<( const $1 &a, const $1 &b )" [ctnameP]
+    --cblock $ do
+    --  forM_ fds $ \fd -> do
+    --    wt "if( a.$1 < b.$1 ) return true;" [fd_fieldName fd]
+    --    wt "if( b.$1 < a.$1 ) return false;" [fd_fieldName fd]
+    --  wl "return false;"
+    --wl ""
+    --genTemplate (s_typeParams s)
+    --wl "bool"
+    --wt "operator==( const $1 &a, const $1 &b )" [ctnameP]
+    --cblock $ do
+    --  if isEmpty
+    --    then wl "return true;"
+    --    else do
+    --      wl "return"
+    --      forM_ (sepWithTerm "&&" ";" fds) $ \(fd,sep) -> do
+    --        indent $ wt "a.$1 == b.$1 $2" [fd_fieldName fd,sep]
 
   write ifileS $ do
     declareSerialisation (s_typeParams s) ms ctnameP
@@ -651,7 +652,7 @@ generateDecl dn d@(Decl{d_type=(Decl_Union u)}) = do
       wt "static void *copy( DiscType d, void *v );" [ctnameP]
     wl "};"
 
-    declareOperators ifile (u_typeParams u) ctnameP
+    -- declareOperators ifile (u_typeParams u) ctnameP
 
   write ifile $ do
     wl ""
@@ -776,37 +777,37 @@ generateDecl dn d@(Decl{d_type=(Decl_Union u)}) = do
                  [fd_unionDiscName fd,fd_typeExpr fd]
       wl "return 0;"
     wl ""
-    genTemplate (u_typeParams u)
-    wl "bool"
-    wt "operator<( const $1 &a, const $1 &b )" [ctnameP]
-    cblock $ do
-      wl "if( a.d() < b.d() ) return true;"
-      wl "if( b.d() < a.d()) return false;"
-      wl "switch( a.d() )"
-      cblock $
-        forM_ fds $ \fd -> do
-          if fd_isVoidType fd
-            then wt "case $1::$2: return false;"
-                 [ctnameP,fd_unionDiscName fd]
-            else wt "case $1::$2: return a.$3() < b.$3();"
-                 [ctnameP,fd_unionDiscName fd,fd_unionAccessorName fd]
-      wl "return false;"
+    --genTemplate (u_typeParams u)
+    --wl "bool"
+    --wt "operator<( const $1 &a, const $1 &b )" [ctnameP]
+    --cblock $ do
+    --  wl "if( a.d() < b.d() ) return true;"
+    --  wl "if( b.d() < a.d()) return false;"
+    --  wl "switch( a.d() )"
+    --  cblock $
+    --    forM_ fds $ \fd -> do
+    --      if fd_isVoidType fd
+    --        then wt "case $1::$2: return false;"
+    --             [ctnameP,fd_unionDiscName fd]
+    --        else wt "case $1::$2: return a.$3() < b.$3();"
+    --             [ctnameP,fd_unionDiscName fd,fd_unionAccessorName fd]
+    --  wl "return false;"
 
-    wl ""
-    genTemplate (u_typeParams u)
-    wl "bool"
-    wt "operator==( const $1 &a, const $1 &b )" [ctnameP]
-    cblock $ do
-      wl "if( a.d() != b.d() ) return false;"
-      wl "switch( a.d() )"
-      cblock $
-        forM_ fds $ \fd -> do
-          if fd_isVoidType fd
-            then wt "case $1::$2: return true;"
-                 [ctnameP,fd_unionDiscName fd]
-            else wt "case $1::$2: return a.$3() == b.$3();"
-                 [ctnameP,fd_unionDiscName fd,fd_unionAccessorName fd]
-      wl "return false;"
+    --wl ""
+    --genTemplate (u_typeParams u)
+    --wl "bool"
+    --wt "operator==( const $1 &a, const $1 &b )" [ctnameP]
+    --cblock $ do
+    --  wl "if( a.d() != b.d() ) return false;"
+    --  wl "switch( a.d() )"
+    --  cblock $
+    --    forM_ fds $ \fd -> do
+    --      if fd_isVoidType fd
+    --        then wt "case $1::$2: return true;"
+    --             [ctnameP,fd_unionDiscName fd]
+    --        else wt "case $1::$2: return a.$3() == b.$3();"
+    --             [ctnameP,fd_unionDiscName fd,fd_unionAccessorName fd]
+    --  wl "return false;"
 
   write ifileS $ do
     declareSerialisation (u_typeParams u) ms ctnameP
@@ -914,11 +915,11 @@ generateDecl dn d@(Decl{d_type=(Decl_Newtype nt)}) = do
        wt "explicit $1(const $2 & v) : value(v) {}" [ctname,t]
        wl ""
        wt "$1 value;" [t]
-    wl ""
-    genTemplateI tparams
-    wt "bool operator<( const $1 &a, const $1 &b ) { return a.value < b.value; }" [ctnameP]
-    genTemplateI tparams
-    wt "bool operator==( const $1 &a, const $1 &b ) { return a.value == b.value; }" [ctnameP]
+    --wl ""
+    --genTemplateI tparams
+    --wt "bool operator<( const $1 &a, const $1 &b ) { return a.value < b.value; }" [ctnameP]
+    --genTemplateI tparams
+    --wt "bool operator==( const $1 &a, const $1 &b ) { return a.value == b.value; }" [ctnameP]
 
   write ifileS $ do
     wl ""

--- a/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
+++ b/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
@@ -643,6 +643,20 @@ generateDecl dn d@(Decl{d_type=(Decl_Union u)}) = do
           wt "$1$2" [fd_unionDiscName fd, sep]
       wl ""
       wl "DiscType d() const;"
+      wl ""
+      wl "// act on contents of the union by a functor (visitor) that must have overloads (or template functions) for all the contained types & enum flags"
+      wl "template<class Visitor>"
+      wl "void visit(Visitor vis) const"
+      wl "{"
+      wl "switch (d())"
+      cblock $
+        forM_ fds $ \fd -> do
+          when (not $ fd_isVoidType fd) $
+            wt "case $1: { vis($2(), std::integral_constant<DiscType, $1>()); break;}" [fd_unionDiscName fd, fd_unionAccessorName fd]
+          when (fd_isVoidType fd) $
+            wt "case $1: { vis(std::integral_constant<DiscType, $1>()); break;}" [fd_unionDiscName fd]
+      wl "}"
+      wl ""
       forM_ fds $ \fd -> do
         when (not $ fd_isVoidType fd) $
           wt "$1 & $2() const;" [(fd_typeExpr fd),fd_unionAccessorName fd]

--- a/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
+++ b/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
@@ -1116,17 +1116,17 @@ writeModuleFile mNamespace mIncFile mFile fileWriter m = do
       guard_name = (T.append (T.intercalate "_" (map T.toUpper (unModuleName (m_name m)))) "_H" )
 
       ifileElements = [ms_incFileUserModule s1,ms_incFileSerialisation s1]
-      ifileLines = [ template "#ifndef $1" [guard_name]
+      ifileLines = map T.stripEnd [ T.concat ["// @", "generated"]
+                   , template "#ifndef $1" [guard_name]
                    , template "#define $1" [guard_name]
                    ] ++ fileLines ifileElements ++
-                   [ template "#endif // $1" [guard_name]
-                   ]
+                   [ template "#endif // $1" [guard_name], "\n\n\n\n" ]
 
       cppfileElements = [ms_cppFileUserModule s1,ms_cppFileSerialisation s1]
-      cppfileLines = fileLines cppfileElements
+      cppfileLines = map T.stripEnd [ T.concat ["// @", "generated"] ] ++ fileLines cppfileElements
 
-  liftIO $ fileWriter (mIncFile (m_name m) ++ ".h") (LBS.fromStrict (T.encodeUtf8 (T.intercalate "\n" ifileLines )))
-  liftIO $ fileWriter (mFile (m_name m) ++ ".cpp") (LBS.fromStrict (T.encodeUtf8 (T.intercalate "\n" cppfileLines)))
+  liftIO $ fileWriter (mIncFile (m_name m) ++ ".h") (LBS.fromStrict (T.encodeUtf8 (T.append (T.stripEnd (T.unlines ifileLines) ) "\n" )))
+  liftIO $ fileWriter (mFile (m_name m) ++ ".cpp") (LBS.fromStrict (T.encodeUtf8 (T.append (T.stripEnd (T.unlines cppfileLines)) "\n" )))
 
 data CppFlags = CppFlags {
   -- all include files will be generated and referenced

--- a/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
+++ b/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
@@ -658,6 +658,9 @@ generateDecl dn d@(Decl{d_type=(Decl_Union u)}) = do
       wl "}"
       wl ""
       forM_ fds $ \fd -> do
+        wt "bool is_$1() const { return d_ == $2; };" [fd_unionAccessorName fd, fd_unionDiscName fd]
+      wl ""
+      forM_ fds $ \fd -> do
         when (not $ fd_isVoidType fd) $
           wt "$1 & $2() const;" [(fd_typeExpr fd),fd_unionAccessorName fd]
         when (not $ fd_isVoidType fd) $

--- a/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
+++ b/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
@@ -997,7 +997,7 @@ generateCustomType n d ct = do
   write ifile $ wl ""
   case ct_generateOrigADLType ct of
     Nothing -> do
-      write ifile $ wt "// $1 excluded due to custom definition" [n]
+      write ifile $ wt "// $1 has custom definition" [n]
     Just i -> do
       write ifile $ wt "// $1 generated as $2 due to custom definition" [n,i]
       write ifile $ wl ""

--- a/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
+++ b/haskell/compiler/src/ADL/Compiler/Backends/Cpp.hs
@@ -822,9 +822,9 @@ generateDecl dn d@(Decl{d_type=(Decl_Union u)}) = do
     cblock $ do
         wt "typedef $1 _T;" [scopedctnameP]
         wl ""
-        wl "struct S_ : public Serialiser<_T>"
+        wl "struct U_ : public Serialiser<_T>"
         dblock $ do
-            wl "S_( const SerialiserFlags & sf )"
+            wl "U_( const SerialiserFlags & sf )"
             indent $ do
               wl ": sf_(sf)"
               wl "{}"
@@ -880,7 +880,7 @@ generateDecl dn d@(Decl{d_type=(Decl_Union u)}) = do
                   wl "return;"
               wl "throw json_parse_failure();"
         wl ""
-        wl "return typename Serialiser<_T>::Ptr( new S_(sf) );"
+        wl "return typename Serialiser<_T>::Ptr( new U_(sf) );"
 
 generateDecl dn d@(Decl{d_type=(Decl_Newtype nt)}) = do
   let te = (n_typeExpr nt)


### PR DESCRIPTION
See each commit individually.

5d47162 TEMP - Workaround to build docker image in ADL
Please ignore / exclude - for discussion

d7ce4fc c++ - comment out operators < and == from generated code
Please help replace by a global flag on the code generator

15304d2 c++ - reworded comment in generated code
7220bb3 c++ - rename S_ to U_ in union serialiser
92f2bab c++ - add typedefs for struct & union members & template args
41b15cf c++ - add @generated & add trailing newline
b931c59 c++ - Add variant visitor pattern accessor in c++ union class
61b1b7f  c++ Add bool is_xxx() convenience method to unions


