### PR TITLE
Adding 'fonts export-ignore' as per haskel doco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ cpp/runtime/ltmain.sh
 cpp/runtime/missing
 cpp/runtime/build/
 cpp/runtime/test-driver
+
+fonts export-ignore


### PR DESCRIPTION
running into issues building hx-deploy-tool , according to the error message, this fixes the problem
https://github.com/commercialhaskell/stack/issues/4579