### PR TITLE
Add all compiler/lib files to data-files

### DIFF
--- a/haskell/compiler/adl-compiler.cabal
+++ b/haskell/compiler/adl-compiler.cabal
@@ -14,6 +14,7 @@ cabal-version:       >=1.8
 data-files:          lib/adl/adlc/config/cpp.adl
                      lib/adl/adlc/config/haskell.adl
                      lib/adl/adlc/config/java.adl
+                     lib/adl/adlc/config/rust.adl
                      lib/adl/adlc/config/typescript.adl
                      lib/adl/sys/adlast.adl
                      lib/adl/sys/adlast.adl-java
@@ -24,10 +25,15 @@ data-files:          lib/adl/adlc/config/cpp.adl
                      lib/adl/sys/types.adl-cpp
                      lib/adl/sys/types.adl-hs
                      lib/adl/sys/types.adl-java
+                     lib/adl/sys/types.adl-rs
                      lib/haskell/runtime/ADL/Core.hs
                      lib/haskell/runtime/ADL/Core/Nullable.hs
                      lib/haskell/runtime/ADL/Core/StringMap.hs
+                     lib/haskell/runtime/ADL/Core/TypeProxy.hs
+                     lib/haskell/runtime/ADL/Core/TypeToken.hs
                      lib/haskell/runtime/ADL/Core/Value.hs
+                     lib/haskell/runtime/ADL/Sys/Adlast.hs
+                     lib/haskell/runtime/ADL/Sys/Types.hs
                      lib/java/runtime/org/adl/runtime/Builders.java
                      lib/java/runtime/org/adl/runtime/ByteArray.java
                      lib/java/runtime/org/adl/runtime/DynamicHelpers.java

--- a/haskell/compiler/adl-compiler.cabal
+++ b/haskell/compiler/adl-compiler.cabal
@@ -11,19 +11,23 @@ category:            Network
 build-type:          Simple
 cabal-version:       >=1.8
 
-data-files:          lib/adl/sys/adlast.adl
+data-files:          lib/adl/adlc/config/cpp.adl
+                     lib/adl/adlc/config/haskell.adl
+                     lib/adl/adlc/config/java.adl
+                     lib/adl/adlc/config/typescript.adl
+                     lib/adl/sys/adlast.adl
                      lib/adl/sys/adlast.adl-java
+                     lib/adl/sys/annotations.adl
                      lib/adl/sys/dynamic.adl
                      lib/adl/sys/dynamic.adl-java
                      lib/adl/sys/types.adl
-                     lib/adl/sys/types.adl-java
-                     lib/adl/sys/types.adl-hs
                      lib/adl/sys/types.adl-cpp
-                     lib/adl/sys/annotations.adl
-                     lib/adl/adlc/config/haskell.adl
-                     lib/adl/adlc/config/cpp.adl
-                     lib/adl/adlc/config/java.adl
-                     lib/adl/adlc/config/typescript.adl
+                     lib/adl/sys/types.adl-hs
+                     lib/adl/sys/types.adl-java
+                     lib/haskell/runtime/ADL/Core.hs
+                     lib/haskell/runtime/ADL/Core/Nullable.hs
+                     lib/haskell/runtime/ADL/Core/StringMap.hs
+                     lib/haskell/runtime/ADL/Core/Value.hs
                      lib/java/runtime/org/adl/runtime/Builders.java
                      lib/java/runtime/org/adl/runtime/ByteArray.java
                      lib/java/runtime/org/adl/runtime/DynamicHelpers.java
@@ -35,20 +39,17 @@ data-files:          lib/adl/sys/adlast.adl
                      lib/java/runtime/org/adl/runtime/JsonBindings.java
                      lib/java/runtime/org/adl/runtime/JsonHelpers.java
                      lib/java/runtime/org/adl/runtime/JsonParseException.java
-                     lib/java/runtime/org/adl/runtime/TypeToken.java
                      lib/java/runtime/org/adl/runtime/Lazy.java
                      lib/java/runtime/org/adl/runtime/MaybeHelpers.java
-                     lib/haskell/runtime/ADL/Core.hs
-                     lib/haskell/runtime/ADL/Core/Value.hs
-                     lib/haskell/runtime/ADL/Core/StringMap.hs
-                     lib/haskell/runtime/ADL/Core/Nullable.hs
+                     lib/java/runtime/org/adl/runtime/TypeToken.java
                      lib/typescript/runtime/adl.ts
-                     lib/typescript/runtime/json.ts
-                     lib/typescript/runtime/utils.ts
                      lib/typescript/runtime/dynamic.ts
-                     lib/typescript/runtime/sys/types.ts
+                     lib/typescript/runtime/json.ts
                      lib/typescript/runtime/sys/adlast.ts
                      lib/typescript/runtime/sys/dynamic.ts
+                     lib/typescript/runtime/sys/types.ts
+                     lib/typescript/runtime/utils.ts
+
 
 library
   exposed-modules:    ADL.Compiler.Backends.AST


### PR DESCRIPTION
Needs all the runtime lib files to be packaged.

In particular TypeToken.hs missing in case of use in camus2