### PR TITLE
Typescript generation - Add make* factory functions for unions

### DIFF
--- a/haskell/compiler/tests/demo1/ts-output/picture.ts
+++ b/haskell/compiler/tests/demo1/ts-output/picture.ts
@@ -21,6 +21,15 @@ export interface Picture_Translated {
 
 export type Picture = Picture_Circle | Picture_Rectangle | Picture_Composed | Picture_Translated;
 
+export interface PictureOpts {
+  circle: Circle;
+  rectangle: Rectangle;
+  composed: Picture[];
+  translated: Translated<Picture>;
+}
+
+export function makePicture<K extends keyof PictureOpts>(kind: K, value: PictureOpts[K]) { return {kind, value}; }
+
 const Picture_AST : ADL.ScopedDecl =
   {"moduleName":"picture","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"circle","default":{"kind":"nothing"},"name":"circle","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"picture","name":"Circle"}},"parameters":[]}},{"annotations":[],"serializedName":"rectangle","default":{"kind":"nothing"},"name":"rectangle","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"picture","name":"Rectangle"}},"parameters":[]}},{"annotations":[],"serializedName":"composed","default":{"kind":"nothing"},"name":"composed","typeExpr":{"typeRef":{"kind":"primitive","value":"Vector"},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"picture","name":"Picture"}},"parameters":[]}]}},{"annotations":[],"serializedName":"translated","default":{"kind":"nothing"},"name":"translated","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"picture","name":"Translated"}},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"picture","name":"Picture"}},"parameters":[]}]}}]}},"name":"Picture","version":{"kind":"nothing"}}};
 

--- a/haskell/compiler/tests/test3/ts-output/test3.ts
+++ b/haskell/compiler/tests/test3/ts-output/test3.ts
@@ -103,6 +103,14 @@ export interface U_F_void {
 
 export type U = U_F_int | U_F_string | U_F_void;
 
+export interface UOpts {
+  f_int: number;
+  f_string: string;
+  f_void: null;
+}
+
+export function makeU<K extends keyof UOpts>(kind: K, value: UOpts[K]) { return {kind, value}; }
+
 const U_AST : ADL.ScopedDecl =
   {"moduleName":"test3","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"f_int","default":{"kind":"nothing"},"name":"f_int","typeExpr":{"typeRef":{"kind":"primitive","value":"Int16"},"parameters":[]}},{"annotations":[],"serializedName":"f_string","default":{"kind":"nothing"},"name":"f_string","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"f_void","default":{"kind":"nothing"},"name":"f_void","typeExpr":{"typeRef":{"kind":"primitive","value":"Void"},"parameters":[]}}]}},"name":"U","version":{"kind":"nothing"}}};
 

--- a/haskell/compiler/tests/test5/ts-output/test5.ts
+++ b/haskell/compiler/tests/test5/ts-output/test5.ts
@@ -22,6 +22,12 @@ export interface U2_V {
 
 export type U2 = U2_V;
 
+export interface U2Opts {
+  v: number;
+}
+
+export function makeU2<K extends keyof U2Opts>(kind: K, value: U2Opts[K]) { return {kind, value}; }
+
 const U2_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"v","default":{"kind":"nothing"},"name":"v","typeExpr":{"typeRef":{"kind":"primitive","value":"Int16"},"parameters":[]}}]}},"name":"U2","version":{"kind":"nothing"}}};
 
@@ -37,6 +43,12 @@ export interface U3_V {
 }
 
 export type U3 = U3_V;
+
+export interface U3Opts {
+  v: number;
+}
+
+export function makeU3<K extends keyof U3Opts>(kind: K, value: U3Opts[K]) { return {kind, value}; }
 
 const U3_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"v","default":{"kind":"just","value":100},"name":"v","typeExpr":{"typeRef":{"kind":"primitive","value":"Int16"},"parameters":[]}}]}},"name":"U3","version":{"kind":"nothing"}}};
@@ -77,6 +89,12 @@ export interface U4_V {
 
 export type U4 = U4_V;
 
+export interface U4Opts {
+  v: S1;
+}
+
+export function makeU4<K extends keyof U4Opts>(kind: K, value: U4Opts[K]) { return {kind, value}; }
+
 const U4_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"v","default":{"kind":"nothing"},"name":"v","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"test5","name":"S1"}},"parameters":[]}}]}},"name":"U4","version":{"kind":"nothing"}}};
 
@@ -92,6 +110,12 @@ export interface U5_V {
 }
 
 export type U5 = U5_V;
+
+export interface U5Opts {
+  v: S1;
+}
+
+export function makeU5<K extends keyof U5Opts>(kind: K, value: U5Opts[K]) { return {kind, value}; }
 
 const U5_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"v","default":{"kind":"just","value":{"f":200}},"name":"v","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"test5","name":"S1"}},"parameters":[]}}]}},"name":"U5","version":{"kind":"nothing"}}};
@@ -109,6 +133,12 @@ export interface U6_V {
 
 export type U6 = U6_V;
 
+export interface U6Opts {
+  v: U3;
+}
+
+export function makeU6<K extends keyof U6Opts>(kind: K, value: U6Opts[K]) { return {kind, value}; }
+
 const U6_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"v","default":{"kind":"nothing"},"name":"v","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"test5","name":"U3"}},"parameters":[]}}]}},"name":"U6","version":{"kind":"nothing"}}};
 
@@ -124,6 +154,12 @@ export interface U7_V {
 }
 
 export type U7 = U7_V;
+
+export interface U7Opts {
+  v: U3;
+}
+
+export function makeU7<K extends keyof U7Opts>(kind: K, value: U7Opts[K]) { return {kind, value}; }
 
 const U7_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"v","default":{"kind":"just","value":{"v":75}},"name":"v","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"test5","name":"U3"}},"parameters":[]}}]}},"name":"U7","version":{"kind":"nothing"}}};
@@ -144,6 +180,13 @@ export interface U8_V2 {
 }
 
 export type U8 = U8_V1 | U8_V2;
+
+export interface U8Opts {
+  v1: S1;
+  v2: number;
+}
+
+export function makeU8<K extends keyof U8Opts>(kind: K, value: U8Opts[K]) { return {kind, value}; }
 
 const U8_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"v1","default":{"kind":"nothing"},"name":"v1","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"test5","name":"S1"}},"parameters":[]}},{"annotations":[],"serializedName":"v2","default":{"kind":"nothing"},"name":"v2","typeExpr":{"typeRef":{"kind":"primitive","value":"Int16"},"parameters":[]}}]}},"name":"U8","version":{"kind":"nothing"}}};
@@ -167,6 +210,14 @@ export interface U9_V3<_T> {
 }
 
 export type U9<T> = U9_V1<T> | U9_V2<T> | U9_V3<T>;
+
+export interface U9Opts<T> {
+  v1: T;
+  v2: number;
+  v3: null;
+}
+
+export function makeU9<T, K extends keyof U9Opts<T>>(kind: K, value: U9Opts<T>[K]) { return {kind, value}; }
 
 const U9_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":["T"],"fields":[{"annotations":[],"serializedName":"v1","default":{"kind":"nothing"},"name":"v1","typeExpr":{"typeRef":{"kind":"typeParam","value":"T"},"parameters":[]}},{"annotations":[],"serializedName":"v2","default":{"kind":"nothing"},"name":"v2","typeExpr":{"typeRef":{"kind":"primitive","value":"Int16"},"parameters":[]}},{"annotations":[],"serializedName":"v3","default":{"kind":"nothing"},"name":"v3","typeExpr":{"typeRef":{"kind":"primitive","value":"Void"},"parameters":[]}}]}},"name":"U9","version":{"kind":"nothing"}}};
@@ -215,6 +266,13 @@ export interface List_Cell<T> {
 }
 
 export type List<T> = List_Null<T> | List_Cell<T>;
+
+export interface ListOpts<T> {
+  null: null;
+  cell: Cell<T>;
+}
+
+export function makeList<T, K extends keyof ListOpts<T>>(kind: K, value: ListOpts<T>[K]) { return {kind, value}; }
 
 const List_AST : ADL.ScopedDecl =
   {"moduleName":"test5","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":["T"],"fields":[{"annotations":[],"serializedName":"null","default":{"kind":"nothing"},"name":"null","typeExpr":{"typeRef":{"kind":"primitive","value":"Void"},"parameters":[]}},{"annotations":[],"serializedName":"cell","default":{"kind":"nothing"},"name":"cell","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"test5","name":"Cell"}},"parameters":[{"typeRef":{"kind":"typeParam","value":"T"},"parameters":[]}]}}]}},"name":"List","version":{"kind":"nothing"}}};

--- a/haskell/compiler/tests/test6/ts-output/sys/adlast.ts
+++ b/haskell/compiler/tests/test6/ts-output/sys/adlast.ts
@@ -77,6 +77,14 @@ export interface TypeRef_Reference {
 
 export type TypeRef = TypeRef_Primitive | TypeRef_TypeParam | TypeRef_Reference;
 
+export interface TypeRefOpts {
+  primitive: Ident;
+  typeParam: Ident;
+  reference: ScopedName;
+}
+
+export function makeTypeRef<K extends keyof TypeRefOpts>(kind: K, value: TypeRefOpts[K]) { return {kind, value}; }
+
 const TypeRef_AST : ADL.ScopedDecl =
   {"moduleName":"sys.adlast","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"primitive","default":{"kind":"nothing"},"name":"primitive","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"Ident"}},"parameters":[]}},{"annotations":[],"serializedName":"typeParam","default":{"kind":"nothing"},"name":"typeParam","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"Ident"}},"parameters":[]}},{"annotations":[],"serializedName":"reference","default":{"kind":"nothing"},"name":"reference","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"ScopedName"}},"parameters":[]}}]}},"name":"TypeRef","version":{"kind":"nothing"}}};
 
@@ -273,6 +281,15 @@ export interface DeclType_Newtype_ {
 
 export type DeclType = DeclType_Struct_ | DeclType_Union_ | DeclType_Type_ | DeclType_Newtype_;
 
+export interface DeclTypeOpts {
+  struct_: Struct;
+  union_: Union;
+  type_: TypeDef;
+  newtype_: NewType;
+}
+
+export function makeDeclType<K extends keyof DeclTypeOpts>(kind: K, value: DeclTypeOpts[K]) { return {kind, value}; }
+
 const DeclType_AST : ADL.ScopedDecl =
   {"moduleName":"sys.adlast","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"struct_","default":{"kind":"nothing"},"name":"struct_","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"Struct"}},"parameters":[]}},{"annotations":[],"serializedName":"union_","default":{"kind":"nothing"},"name":"union_","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"Union"}},"parameters":[]}},{"annotations":[],"serializedName":"type_","default":{"kind":"nothing"},"name":"type_","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"TypeDef"}},"parameters":[]}},{"annotations":[],"serializedName":"newtype_","default":{"kind":"nothing"},"name":"newtype_","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"NewType"}},"parameters":[]}}]}},"name":"DeclType","version":{"kind":"nothing"}}};
 
@@ -361,6 +378,13 @@ export interface Import_ScopedName {
 }
 
 export type Import = Import_ModuleName | Import_ScopedName;
+
+export interface ImportOpts {
+  moduleName: ModuleName;
+  scopedName: ScopedName;
+}
+
+export function makeImport<K extends keyof ImportOpts>(kind: K, value: ImportOpts[K]) { return {kind, value}; }
 
 const Import_AST : ADL.ScopedDecl =
   {"moduleName":"sys.adlast","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"moduleName","default":{"kind":"nothing"},"name":"moduleName","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"ModuleName"}},"parameters":[]}},{"annotations":[],"serializedName":"scopedName","default":{"kind":"nothing"},"name":"scopedName","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.adlast","name":"ScopedName"}},"parameters":[]}}]}},"name":"Import","version":{"kind":"nothing"}}};

--- a/haskell/compiler/tests/test6/ts-output/sys/types.ts
+++ b/haskell/compiler/tests/test6/ts-output/sys/types.ts
@@ -39,6 +39,13 @@ export interface Either_Right<_T1, T2> {
 
 export type Either<T1, T2> = Either_Left<T1, T2> | Either_Right<T1, T2>;
 
+export interface EitherOpts<T1, T2> {
+  left: T1;
+  right: T2;
+}
+
+export function makeEither<T1, T2, K extends keyof EitherOpts<T1, T2>>(kind: K, value: EitherOpts<T1, T2>[K]) { return {kind, value}; }
+
 const Either_AST : ADL.ScopedDecl =
   {"moduleName":"sys.types","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":["T1","T2"],"fields":[{"annotations":[],"serializedName":"left","default":{"kind":"nothing"},"name":"left","typeExpr":{"typeRef":{"kind":"typeParam","value":"T1"},"parameters":[]}},{"annotations":[],"serializedName":"right","default":{"kind":"nothing"},"name":"right","typeExpr":{"typeRef":{"kind":"typeParam","value":"T2"},"parameters":[]}}]}},"name":"Either","version":{"kind":"nothing"}}};
 
@@ -57,6 +64,13 @@ export interface Maybe_Just<T> {
 }
 
 export type Maybe<T> = Maybe_Nothing<T> | Maybe_Just<T>;
+
+export interface MaybeOpts<T> {
+  nothing: null;
+  just: T;
+}
+
+export function makeMaybe<T, K extends keyof MaybeOpts<T>>(kind: K, value: MaybeOpts<T>[K]) { return {kind, value}; }
 
 const Maybe_AST : ADL.ScopedDecl =
   {"moduleName":"sys.types","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":["T"],"fields":[{"annotations":[],"serializedName":"nothing","default":{"kind":"nothing"},"name":"nothing","typeExpr":{"typeRef":{"kind":"primitive","value":"Void"},"parameters":[]}},{"annotations":[],"serializedName":"just","default":{"kind":"nothing"},"name":"just","typeExpr":{"typeRef":{"kind":"typeParam","value":"T"},"parameters":[]}}]}},"name":"Maybe","version":{"kind":"nothing"}}};
@@ -77,6 +91,13 @@ export interface Error_Error<_T> {
 }
 
 export type Error<T> = Error_Value<T> | Error_Error<T>;
+
+export interface ErrorOpts<T> {
+  value: T;
+  error: string;
+}
+
+export function makeError<T, K extends keyof ErrorOpts<T>>(kind: K, value: ErrorOpts<T>[K]) { return {kind, value}; }
 
 const Error_AST : ADL.ScopedDecl =
   {"moduleName":"sys.types","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":["T"],"fields":[{"annotations":[],"serializedName":"value","default":{"kind":"nothing"},"name":"value","typeExpr":{"typeRef":{"kind":"typeParam","value":"T"},"parameters":[]}},{"annotations":[],"serializedName":"error","default":{"kind":"nothing"},"name":"error","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}}]}},"name":"Error","version":{"kind":"nothing"}}};


### PR DESCRIPTION
Typescript generation - Add make* factory functions for unions

So that there is a function to prompt and typecheck on what kinds & values
can be put in.

Otherwise the alternative is direct build of
```
{
  kind: 'xxx',
  value: ...
}
```
values which are not typechecked until used/inferred in context.

Enum style unions not included yet.


So an ADL union

```
union BasicUnion {
  String optionA;
  Int64 optionB;
};
```

generates:

```
export interface BasicUnion_OptionA {
  kind: 'optionA';
  value: string;
}
export interface BasicUnion_OptionB {
  kind: 'optionB';
  value: number;
}

export type BasicUnion = BasicUnion_OptionA | BasicUnion_OptionB;

export interface BasicUnionOpts {
  optionA: string;
  optionB: number;
}

export function makeBasicUnion<K extends keyof BasicUnionOpts>(kind: K, value: BasicUnionOpts[K]) { return {kind, value}; }
```


And a type parameterised union eg:
```
union TypeParamedUnion<T> {
  T optionT;
  Int64 optionB;
};
```

generates:
```
export interface TypeParamedUnion_OptionT<T> {
  kind: 'optionT';
  value: T;
}
export interface TypeParamedUnion_OptionB<_T> {
  kind: 'optionB';
  value: number;
}

export type TypeParamedUnion<T> = TypeParamedUnion_OptionT<T> | TypeParamedUnion_OptionB<T>;

export interface TypeParamedUnionOpts<T> {
  optionT: T;
  optionB: number;
}

export function makeTypeParamedUnion<T, K extends keyof TypeParamedUnionOpts<T>>(kind: K, value: TypeParamedUnionOpts<T>[K]) { return {kind, value}; }
```
