### PR TITLE
Fix java code generation for references to types of the same name

### DIFF
--- a/haskell/compiler/tests/Tests.hs
+++ b/haskell/compiler/tests/Tests.hs
@@ -363,6 +363,9 @@ runTests = do
     it "generated code for SerializedWithInternalTag union annotation" $ do
       collectResults (runJavaBackend1 "test26/input/test26.adl")
         `shouldReturn` MatchOutput
+    it "generated code for types that reference another type of the same name" $ do
+      collectResults (runJavaBackend1 "test27/input/test27.adl")
+        `shouldReturn` MatchOutput
     it "Generates the correct code for the picture demo" $ do
       collectResults (runJavaBackend1 "demo1/input/picture.adl")
         `shouldReturn` MatchOutput

--- a/haskell/compiler/tests/demo1/java-output/adl/picture/Picture.java
+++ b/haskell/compiler/tests/demo1/java-output/adl/picture/Picture.java
@@ -186,8 +186,8 @@ public class Picture {
   public static JsonBinding<Picture> jsonBinding() {
     final Lazy<JsonBinding<Circle>> circle = new Lazy<>(() -> Circle.jsonBinding());
     final Lazy<JsonBinding<Rectangle>> rectangle = new Lazy<>(() -> Rectangle.jsonBinding());
-    final Lazy<JsonBinding<ArrayList<Picture>>> composed = new Lazy<>(() -> JsonBindings.arrayList(adl.picture.Picture.jsonBinding()));
-    final Lazy<JsonBinding<Translated<Picture>>> translated = new Lazy<>(() -> Translated.jsonBinding(adl.picture.Picture.jsonBinding()));
+    final Lazy<JsonBinding<ArrayList<Picture>>> composed = new Lazy<>(() -> JsonBindings.arrayList(Picture.jsonBinding()));
+    final Lazy<JsonBinding<Translated<Picture>>> translated = new Lazy<>(() -> Translated.jsonBinding(Picture.jsonBinding()));
     final Factory<Picture> _factory = FACTORY;
 
     return new JsonBinding<Picture>() {

--- a/haskell/compiler/tests/test2/java-output/adl/test2/Tree.java
+++ b/haskell/compiler/tests/test2/java-output/adl/test2/Tree.java
@@ -139,7 +139,7 @@ public class Tree<T> {
 
   public static<T> JsonBinding<Tree<T>> jsonBinding(JsonBinding<T> bindingT) {
     final Lazy<JsonBinding<T>> value = new Lazy<>(() -> bindingT);
-    final Lazy<JsonBinding<ArrayList<Tree<T>>>> children = new Lazy<>(() -> JsonBindings.arrayList(adl.test2.Tree.jsonBinding(bindingT)));
+    final Lazy<JsonBinding<ArrayList<Tree<T>>>> children = new Lazy<>(() -> JsonBindings.arrayList(Tree.jsonBinding(bindingT)));
     final Factory<T> factoryT = bindingT.factory();
     final Factory<Tree<T>> _factory = factory(bindingT.factory());
 

--- a/haskell/compiler/tests/test27/input/test27.adl
+++ b/haskell/compiler/tests/test27/input/test27.adl
@@ -1,0 +1,9 @@
+module test27 {
+
+struct Message {
+  test27a.Message other;
+  test27a.Message2 other2;
+};
+
+};
+

--- a/haskell/compiler/tests/test27/input/test27a.adl
+++ b/haskell/compiler/tests/test27/input/test27a.adl
@@ -1,0 +1,11 @@
+module test27a {
+   
+struct Message {
+  String field;
+};
+
+struct Message2 {
+  String field2;
+};
+
+};

--- a/haskell/compiler/tests/test27/java-output/adl/test27/Message.java
+++ b/haskell/compiler/tests/test27/java-output/adl/test27/Message.java
@@ -1,0 +1,166 @@
+/* @generated from adl module test27 */
+
+package adl.test27;
+
+import adl.test27a.Message2;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.adl.runtime.Builders;
+import org.adl.runtime.Factory;
+import org.adl.runtime.JsonBinding;
+import org.adl.runtime.JsonBindings;
+import org.adl.runtime.Lazy;
+import org.adl.runtime.sys.adlast.ScopedName;
+import org.adl.runtime.sys.adlast.TypeExpr;
+import org.adl.runtime.sys.adlast.TypeRef;
+import java.util.ArrayList;
+import java.util.Objects;
+
+public class Message {
+
+  /* Members */
+
+  private adl.test27a.Message other;
+  private Message2 other2;
+
+  /* Constructors */
+
+  public Message(adl.test27a.Message other, Message2 other2) {
+    this.other = Objects.requireNonNull(other);
+    this.other2 = Objects.requireNonNull(other2);
+  }
+
+  public Message() {
+    this.other = new adl.test27a.Message();
+    this.other2 = new Message2();
+  }
+
+  public Message(Message other) {
+    this.other = adl.test27a.Message.FACTORY.create(other.other);
+    this.other2 = Message2.FACTORY.create(other.other2);
+  }
+
+  /* Accessors and mutators */
+
+  public adl.test27a.Message getOther() {
+    return other;
+  }
+
+  public void setOther(adl.test27a.Message other) {
+    this.other = Objects.requireNonNull(other);
+  }
+
+  public Message2 getOther2() {
+    return other2;
+  }
+
+  public void setOther2(Message2 other2) {
+    this.other2 = Objects.requireNonNull(other2);
+  }
+
+  /* Object level helpers */
+
+  @Override
+  public boolean equals(Object other0) {
+    if (!(other0 instanceof Message)) {
+      return false;
+    }
+    Message other = (Message) other0;
+    return
+      other.equals(other.other) &&
+      other2.equals(other.other2);
+  }
+
+  @Override
+  public int hashCode() {
+    int _result = 1;
+    _result = _result * 37 + other.hashCode();
+    _result = _result * 37 + other2.hashCode();
+    return _result;
+  }
+
+  /* Builder */
+
+  public static class Builder {
+    private adl.test27a.Message other;
+    private Message2 other2;
+
+    public Builder() {
+      this.other = null;
+      this.other2 = null;
+    }
+
+    public Builder setOther(adl.test27a.Message other) {
+      this.other = Objects.requireNonNull(other);
+      return this;
+    }
+
+    public Builder setOther2(Message2 other2) {
+      this.other2 = Objects.requireNonNull(other2);
+      return this;
+    }
+
+    public Message create() {
+      Builders.checkFieldInitialized("Message", "other", other);
+      Builders.checkFieldInitialized("Message", "other2", other2);
+      return new Message(other, other2);
+    }
+  }
+
+  /* Factory for construction of generic values */
+
+  public static final Factory<Message> FACTORY = new Factory<Message>() {
+    @Override
+    public Message create() {
+      return new Message();
+    }
+
+    @Override
+    public Message create(Message other) {
+      return new Message(other);
+    }
+
+    @Override
+    public TypeExpr typeExpr() {
+      ScopedName scopedName = new ScopedName("test27", "Message");
+      ArrayList<TypeExpr> params = new ArrayList<>();
+      return new TypeExpr(TypeRef.reference(scopedName), params);
+    }
+    @Override
+    public JsonBinding<Message> jsonBinding() {
+      return Message.jsonBinding();
+    }
+  };
+
+  /* Json serialization */
+
+  public static JsonBinding<Message> jsonBinding() {
+    final Lazy<JsonBinding<adl.test27a.Message>> other = new Lazy<>(() -> adl.test27a.Message.jsonBinding());
+    final Lazy<JsonBinding<Message2>> other2 = new Lazy<>(() -> Message2.jsonBinding());
+    final Factory<Message> _factory = FACTORY;
+
+    return new JsonBinding<Message>() {
+      @Override
+      public Factory<Message> factory() {
+        return _factory;
+      }
+
+      @Override
+      public JsonElement toJson(Message _value) {
+        JsonObject _result = new JsonObject();
+        _result.add("other", other.get().toJson(_value.other));
+        _result.add("other2", other2.get().toJson(_value.other2));
+        return _result;
+      }
+
+      @Override
+      public Message fromJson(JsonElement _json) {
+        JsonObject _obj = JsonBindings.objectFromJson(_json);
+        return new Message(
+          JsonBindings.fieldFromJson(_obj, "other", other.get()),
+          JsonBindings.fieldFromJson(_obj, "other2", other2.get())
+        );
+      }
+    };
+  }
+}

--- a/haskell/compiler/tests/test6/java-output/org/adl/runtime/sys/adlast/ScopedName.java
+++ b/haskell/compiler/tests/test6/java-output/org/adl/runtime/sys/adlast/ScopedName.java
@@ -119,7 +119,7 @@ public class ScopedName {
 
     @Override
     public TypeExpr typeExpr() {
-      org.adl.runtime.sys.adlast.ScopedName scopedName = new org.adl.runtime.sys.adlast.ScopedName("sys.adlast", "ScopedName");
+      ScopedName scopedName = new ScopedName("sys.adlast", "ScopedName");
       ArrayList<TypeExpr> params = new ArrayList<>();
       return new TypeExpr(TypeRef.reference(scopedName), params);
     }

--- a/haskell/compiler/tests/test6/java-output/org/adl/runtime/sys/adlast/TypeExpr.java
+++ b/haskell/compiler/tests/test6/java-output/org/adl/runtime/sys/adlast/TypeExpr.java
@@ -118,10 +118,10 @@ public class TypeExpr {
     }
 
     @Override
-    public org.adl.runtime.sys.adlast.TypeExpr typeExpr() {
+    public TypeExpr typeExpr() {
       ScopedName scopedName = new ScopedName("sys.adlast", "TypeExpr");
-      ArrayList<org.adl.runtime.sys.adlast.TypeExpr> params = new ArrayList<>();
-      return new org.adl.runtime.sys.adlast.TypeExpr(TypeRef.reference(scopedName), params);
+      ArrayList<TypeExpr> params = new ArrayList<>();
+      return new TypeExpr(TypeRef.reference(scopedName), params);
     }
     @Override
     public JsonBinding<TypeExpr> jsonBinding() {
@@ -133,7 +133,7 @@ public class TypeExpr {
 
   public static JsonBinding<TypeExpr> jsonBinding() {
     final Lazy<JsonBinding<TypeRef>> typeRef = new Lazy<>(() -> TypeRef.jsonBinding());
-    final Lazy<JsonBinding<ArrayList<TypeExpr>>> parameters = new Lazy<>(() -> JsonBindings.arrayList(org.adl.runtime.sys.adlast.TypeExpr.jsonBinding()));
+    final Lazy<JsonBinding<ArrayList<TypeExpr>>> parameters = new Lazy<>(() -> JsonBindings.arrayList(TypeExpr.jsonBinding()));
     final Factory<TypeExpr> _factory = FACTORY;
 
     return new JsonBinding<TypeExpr>() {

--- a/haskell/compiler/tests/test6/java-output/org/adl/runtime/sys/adlast/TypeRef.java
+++ b/haskell/compiler/tests/test6/java-output/org/adl/runtime/sys/adlast/TypeRef.java
@@ -144,7 +144,7 @@ public class TypeRef {
     public TypeExpr typeExpr() {
       ScopedName scopedName = new ScopedName("sys.adlast", "TypeRef");
       ArrayList<TypeExpr> params = new ArrayList<>();
-      return new TypeExpr(org.adl.runtime.sys.adlast.TypeRef.reference(scopedName), params);
+      return new TypeExpr(TypeRef.reference(scopedName), params);
     }
 
     @Override


### PR DESCRIPTION
Fixes the problem where ADL like this:

```
module a {
   struct M {};
};

module b {
   struct M {
     a.M field;
   };
};
```

was failing to correctly import a.M in the java generated code for module b.